### PR TITLE
Add failure tree diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # agent-cellphone-cli
+
+This README is the single source of truth (SSOT) for project information and diagrams.
+
+## Failure Tree
+
+The following Mermaid diagram is the SSOT for failure analysis.
+
+```mermaid
+flowchart TD
+    Failure[Call failure]
+    Failure --> LowBattery[Low battery]
+    Failure --> NoSignal[No signal]
+    LowBattery --> Depleted[Battery depleted]
+    LowBattery --> Defective[Battery defective]
+    NoSignal --> OutOfRange[Out of range]
+    NoSignal --> SIMIssue[SIM malfunction]
+```
+


### PR DESCRIPTION
## Summary
- document project SSOT and failure tree diagram in README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99952b25883299980bba29aa7a17b